### PR TITLE
fix parameter difinition

### DIFF
--- a/Casks/stm32cubeide.rb
+++ b/Casks/stm32cubeide.rb
@@ -2,7 +2,7 @@ cask "stm32cubeide" do
   version "1.6.0"
   sha256 :no_check
 
-  url "https://www.dropbox.com/s/5n4qgtjvp9ehnei/en.stm32cubeide_v1.6.0.dmg?dl=1", header: "", data: "",
+  url "https://www.dropbox.com/s/5n4qgtjvp9ehnei/en.stm32cubeide_v1.6.0.dmg?dl=1", header: "", data: nil,
       verified: "dropbox.com/s/5n4qgtjvp9ehnei"
   name "STM32CubeIDE"
   desc "Integrated Development Environment for STM32"

--- a/Casks/stm32cubemx.rb
+++ b/Casks/stm32cubemx.rb
@@ -16,7 +16,7 @@ cask "stm32cubemx" do
   version "6.2.0"
   sha256 :no_check
 
-  url "https://www.dropbox.com/s/oega5zar68w8b0p/en.stm32cubemx_v6.2.0.zip?dl=1", header: "", data: "",
+  url "https://www.dropbox.com/s/oega5zar68w8b0p/en.stm32cubemx_v6.2.0.zip?dl=1", header: "", data: nil,
       verified: "dropbox.com/s/oega5zar68w8b0p"
   name "STM32CubeMX"
   desc "STM32Cube initialization code generator"


### PR DESCRIPTION
PR for fix this error:

```shell
$ brew info stm32cubemx
Error: Cask 'stm32cubemx' definition is invalid: 'url' stanza failed with: Parameter 'data': Expected type T.nilable(T::Hash[String, String]), got type String with value ""
Caller: /usr/local/Homebrew/Library/Homebrew/vendor/bundle/ruby/2.6.0/gems/sorbet-runtime-0.5.10461/lib/types/private/methods/call_validation.rb:113
Definition: /usr/local/Homebrew/Library/Homebrew/cask/url.rb:172
```
